### PR TITLE
Changes for 1-HR ELF

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,7 +1,7 @@
 class ApplicationController < ActionController::Base
   include ApplicationHelper
 
-  SALESFORCE_API_VERSION = "32.0"
+  SALESFORCE_API_VERSION = "37.0"
 
   # Prevent CSRF attacks by raising an exception.
   # For APIs, you may want to use :null_session instead.

--- a/app/controllers/event_log_files_controller.rb
+++ b/app/controllers/event_log_files_controller.rb
@@ -2,17 +2,19 @@ class EventLogFilesController < ApplicationController
   include ActionController::Live
 
   ALL_EVENTS_TYPE = "All"
-  
+
   before_filter :setup_databasedotcom_client
 
   def index
     redirect_to root_path unless logged_in?
 
     @username = session[:username]
-    if not session.has_key?("event_types")
-      session[:event_types] = get_event_types
+
+    unless metadata_cached?
+      load_and_cache_elf_metadata
     end
     @event_types = session["event_types"]
+    @has_one_hr_elf = session["has_one_hr_elf"]
 
     if params[:daterange].nil? && params[:eventtype].nil?
       default_params_redirect
@@ -44,10 +46,16 @@ class EventLogFilesController < ApplicationController
     end
 
     begin
+      @select_clause = "SELECT Id, EventType, LogDate, LogFileLength"
+      @order_by_clause = "ORDER BY LogDate DESC, EventType"
+      if @has_one_hr_elf
+        @select_clause = "SELECT Id, EventType, LogDate, LogFileLength, Sequence, Interval"
+        @order_by_clause = "ORDER BY LogDate DESC, EventType, Sequence, Interval"
+      end
       if @event_type == ALL_EVENTS_TYPE
-        @log_files = @client.query("SELECT Id, EventType, LogDate, LogFileLength FROM EventLogFile WHERE LogDate >= #{date_to_time(@start_date)} AND LogDate <= #{date_to_time(@end_date)} ORDER BY LogDate DESC, EventType")
+        @log_files = @client.query("#{@select_clause} FROM EventLogFile WHERE LogDate >= #{date_to_time(@start_date)} AND LogDate <= #{date_to_time(@end_date)} #{@order_by_clause}")
       else
-        @log_files = @client.query("SELECT Id, EventType, LogDate, LogFileLength FROM EventLogFile WHERE LogDate >= #{date_to_time(@start_date)} AND LogDate <= #{date_to_time(@end_date)} AND EventType = '#{@event_type}' ORDER BY LogDate DESC, EventType" )
+        @log_files = @client.query("#{@select_clause} FROM EventLogFile WHERE LogDate >= #{date_to_time(@start_date)} AND LogDate <= #{date_to_time(@end_date)} AND EventType = '#{@event_type}' #{@order_by_clause}")
       end
     rescue Databasedotcom::SalesForceError => e
       # Session has expired. Force user logout.
@@ -132,16 +140,34 @@ class EventLogFilesController < ApplicationController
   end
 
   # helper method to dynamically generate the valid event log file event types
-  def get_event_types
+  def get_event_types(fields)
     pick_list_values = []
-    fields = @client.describe_sobject("EventLogFile")["fields"]
     for field in fields
       if field["name"] == "EventType"
-         field["picklistValues"].each {|v| pick_list_values.push(v["value"])}
+        field["picklistValues"].each {|v| pick_list_values.push(v["value"])}
         break
       end
     end
     return pick_list_values.dup.unshift(ALL_EVENTS_TYPE)
   end
 
+  # helper method to identify whether an org has 1-hr ELF
+  def one_hour_elf?(fields)
+    for field in fields
+      if field["name"] == "Interval" or field["name"] == "Sequence"
+        return "1"
+      end
+    end
+    return nil
+  end
+
+  def metadata_cached?
+    session[:event_types] || session[:has_one_hr_elf]
+  end
+
+  def load_and_cache_elf_metadata
+    fields = @client.describe_sobject("EventLogFile")["fields"]
+    session[:event_types] = get_event_types(fields)
+    session[:has_one_hr_elf] = one_hour_elf?(fields)
+  end
 end

--- a/app/views/event_log_files/index.html.haml
+++ b/app/views/event_log_files/index.html.haml
@@ -54,7 +54,12 @@
         %th Action
         %th Event Type
         %th Log Date
+        - if @has_one_hr_elf
+          %th Log Hour
         %th Log Size (in bytes)
+        - if @has_one_hr_elf
+          %th Sequence
+          %th Interval
 
     %tbody
       - @log_files.each do |log_file|
@@ -73,5 +78,13 @@
             = log_file.EventType
           %td
             = log_file.LogDate.strftime("%Y-%m-%d")
+          - if @has_one_hr_elf
+            %td
+              = log_file.LogDate.strftime("%H")
           %td.text-right
             = number_with_delimiter(log_file.LogFileLength)
+          - if @has_one_hr_elf
+            %td
+              = log_file.Sequence
+            %td
+              = log_file.Interval


### PR DESCRIPTION
Show Log Hour, Sequence, and Interval columns if org has 1-HR ELF.
Records are ordered by LogDate DESC, EventType, Sequence, Interval for 1-HR ELF org.
Updated SALESFORCE_API_VERSION to 37.
